### PR TITLE
fix node version

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,7 +14,7 @@ RUN mkdir -p "$HOME/.nodenv"/plugins
 RUN git clone https://github.com/nodenv/node-build.git "$HOME/.nodenv"/plugins/node-build
 
  # Arielのnodeバージョンと揃える
-RUN $HOME/.nodenv/bin/nodenv install 18.17.1 
-RUN $HOME/.nodenv/bin/nodenv global 18.17.1
+RUN $HOME/.nodenv/bin/nodenv install 22.12.0
+RUN $HOME/.nodenv/bin/nodenv global 22.12.0
 
 RUN curl -sSfL https://assets.path.progate.com/cli-installer/out/setup.sh | bash -s -- -y


### PR DESCRIPTION
Path のコンテンツに合わせて Node.js のバージョンを `22.12.0` にあげました。